### PR TITLE
Minor packaging tweaks

### DIFF
--- a/rpm/x509-scitokens-issuer.spec
+++ b/rpm/x509-scitokens-issuer.spec
@@ -12,6 +12,7 @@ Source0:        %{name}-%{version}.tar.gz
  
 %{?systemd_requires}
 
+BuildRequires:  cmake
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools
 

--- a/src/x509_scitokens_issuer/x509_scitokens_issuer.py
+++ b/src/x509_scitokens_issuer/x509_scitokens_issuer.py
@@ -28,6 +28,8 @@ def _load_default_config():
         "ENABLED": False
     })
     app.config.from_pyfile("x509_scitokens_issuer.cfg")
+    if os.environ.get('X509_SCITOKENS_ISSUER'):
+        app.config.from_envvar("X509_SCITOKENS_ISSUER")
     config_glob = str(app.config['CONFIG_FILE_GLOB'])
     files = glob.glob(config_glob)
     files.sort()


### PR DESCRIPTION
- Add in missing build-time dependency.
- Allow the OS environment to specify which config file to use.  Simplifies deployment of multiple issuers on one Apache host.