### PR TITLE
Add start-up flexibility via env variables

### DIFF
--- a/src/x509_scitokens_issuer/x509_scitokens_issuer.py
+++ b/src/x509_scitokens_issuer/x509_scitokens_issuer.py
@@ -1,4 +1,4 @@
-
+from __future__ import print_function
 import os
 import re
 import glob
@@ -51,11 +51,11 @@ def _load_default_config():
     files = glob.glob(config_glob)
     files.sort()
     for fname in files:
-        print "Loading configuration file %s" % fname
+        print("Loading configuration file %s" % fname)
         app.config.from_pyfile(fname)
 
 _load_default_config()
-print "Loading X509 SciTokens issuer with the following config: %s" % str(app.config)
+print("Loading X509 SciTokens issuer with the following config: %s" % str(app.config))
 
 class InvalidFQAN(Exception):
     pass
@@ -161,8 +161,8 @@ def update_app():
 
     app.users_mapping = users_mapping
     app.rules = rule_list
-    print "Users mapping has %d rules" % len(app.users_mapping)
-    print "App rules:", app.rules
+    print("Users mapping has %d rules" % len(app.users_mapping))
+    print("App rules:", app.rules)
 
     with open(app.config['ISSUER_KEY'], 'r') as fd:
         json_obj = json.load(fd)
@@ -181,7 +181,7 @@ def launch_updater_thread():
         try:
             update_app()
         except Exception, e:
-            print "Failure occurred when trying to update the app config:", str(e)
+            print("Failure occurred when trying to update the app config:", str(e))
             traceback.print_exc()
         if repeat:
             time.sleep(60)

--- a/src/x509_scitokens_issuer/x509_scitokens_issuer.py
+++ b/src/x509_scitokens_issuer/x509_scitokens_issuer.py
@@ -28,21 +28,18 @@ app.updater_thread = None
 app.issuer_key = None
 
 def _load_default_config():
+    conf = {
+    "CONFIG_FILE_GLOB": "/etc/x509-scitokens-issuer/conf.d/*.cfg",
+    "LIFETIME": 3600,
+    "ISSUER_KEY": "/etc/x509-scitokens-issuer/issuer_key.jwks",
+    "RULES": "/etc/x509-scitokens-issuer/rules.json",
+    "DN_MAPPING": "/var/cache/httpd/x509-scitokens-issuer/dn_mapping.json",
+    "ENABLED": False
+    }
     aconf = os.environ.get('X509_SCITOKENS_ISSUER_CONFIG', '')
     if aconf:
         print("Loading {} config".format(aconf))
-        conf = json.load(open(aconf))
-    else:
-        print("Loading default config")
-        conf = {
-        "CONFIG_FILE_GLOB": "/etc/x509-scitokens-issuer/conf.d/*.cfg",
-        "LIFETIME": 3600,
-        "ISSUER_KEY": "/etc/x509-scitokens-issuer/issuer_key.jwks",
-        "RULES": "/etc/x509-scitokens-issuer/rules.json",
-        "DN_MAPPING": "/var/cache/httpd/x509-scitokens-issuer/dn_mapping.json",
-        "ENABLED": False
-        }
-
+        conf.update(json.load(open(aconf)))
     app.config.update(conf)
     app.config.from_pyfile("x509_scitokens_issuer.cfg")
     if os.environ.get('X509_SCITOKENS_ISSUER'):


### PR DESCRIPTION
For cmsweb deployment we need to use custom paths. This PR provides enough flexibility to specify instance path and configuration file to be used by flask to start up the service.