### PR TITLE
Fixing bug that prevented running on el8

### DIFF
--- a/rpm/x509-scitokens-issuer.spec
+++ b/rpm/x509-scitokens-issuer.spec
@@ -1,5 +1,5 @@
 Name:           x509-scitokens-issuer
-Version:        0.8.0
+Version:        0.8.1
 Release:        1%{?dist}
 Summary:        SciTokens issuer based on X509 authentication.
 
@@ -149,6 +149,9 @@ fi
 %{_bindir}/macaroon-init
 
 %changelog
+* Mon Oct 26 2020 Edgar Fajardo <emfajard@ucsd.edu> - 0.8.1-1
+- Fix bug preventing macaroon-init for EL8
+
 * Tue Aug 18 2020 Edgar Fajardo <emfajard@ucsd.edu> - 0.8.0-1
 - Adding support for EL8
 

--- a/tools/macaroon-init.cpp
+++ b/tools/macaroon-init.cpp
@@ -19,8 +19,8 @@ int main(int argc, char *argv[])
     const char *url = argv[1];
     int validity = std::stoi(argv[2]);
 
-    std::vector<const char *> activities_list;
-    activities_list.reserve(argc-2);
+    std::vector<const char *> activities_list(argc-2);
+
     for (int idx=0; idx<argc-3; idx++)
     {
         activities_list[idx] = argv[idx+3];


### PR DESCRIPTION
Before it was crashing on EL8 with error:

```
macaroon-init https://test-008.t2.ucsd.edu:9001/usr/share/osg-test/test_gridftp_data.txt 20 DOWNLOAD
/usr/include/c++/8/bits/stl_vector.h:932: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = const char*; _Alloc = std::allocator<const char*>; std::vector<_Tp, _Alloc>::reference = const char*&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.
Aborted (core dumped)
```